### PR TITLE
Make plugin interface easier to use

### DIFF
--- a/packages/example/next.config.js
+++ b/packages/example/next.config.js
@@ -1,6 +1,7 @@
-const withMinifyClassnames = require('nextjs-plugin-minify-css-classname')({
-  enable: true,
-});
+// const withMinifyClassnames = require('nextjs-plugin-minify-css-classname')({
+//   enabled: true,
+// });
+const withMinifyClassnames = require('nextjs-plugin-minify-css-classname');
 
 module.exports = withMinifyClassnames({
   cssModules: true,

--- a/packages/nextjs-plugin-minify-css-classname/README.md
+++ b/packages/nextjs-plugin-minify-css-classname/README.md
@@ -38,6 +38,16 @@ $ yarn add -D nextjs-plugin-minify-css-classname
 ## :surfer: Usage
 __next.config.js__
 ```js
+// Automatically enable on production build
+const withMinifyClassname = require('nextjs-plugin-minify-css-classname');
+
+module.exports = withMinifyClassname({
+  // other configs
+})
+```
+
+```js
+// or manually enable
 const withMinifyClassname = require('nextjs-plugin-minify-css-classname')({
   enabled: process.env.NODE_ENV === 'production',
 });

--- a/packages/nextjs-plugin-minify-css-classname/src/index.spec.ts
+++ b/packages/nextjs-plugin-minify-css-classname/src/index.spec.ts
@@ -1,0 +1,19 @@
+import withMinifyClassnames, { Config } from '.';
+import type { NextConfig } from 'next';
+
+describe('withMinifyClassnames', () => {
+  it('directly decorate argument when takes NextConfig.', () => {
+    const config: NextConfig = { cssModule: true };
+    const result: NextConfig = withMinifyClassnames(config);
+
+    expect(result).toHaveProperty('cssModule', true);
+    expect(result.webpack).toBeInstanceOf(Function);
+  });
+
+  it('returns NextConfig decorator when takes plugin configs.', () => {
+    const config: Config = { enabled: true };
+    const result = withMinifyClassnames(config);
+
+    expect(result).toBeInstanceOf(Function);
+  });
+});

--- a/packages/nextjs-plugin-minify-css-classname/src/index.ts
+++ b/packages/nextjs-plugin-minify-css-classname/src/index.ts
@@ -16,12 +16,11 @@ const getMinifiedLocalIdent = (
   return localIdentGenerator.get(`${relativePath}-${exportName}`);
 };
 
-type Config = {
-  enabled?: boolean;
-};
-const withMinifyClassnames =
-  ({ enabled }: Config) =>
-  (originalNextConfig: NextConfig): NextConfig => ({
+const generateUpdateNextConfig =
+  (enabled?: boolean) =>
+  (
+    originalNextConfig: NextConfig
+  ): NextConfig & { webpack: NonNullable<NextConfig['webpack']> } => ({
     ...originalNextConfig,
     webpack(config, context) {
       const webpackResult =
@@ -56,5 +55,18 @@ const withMinifyClassnames =
       return webpackResult;
     },
   });
+
+export type Config = {
+  enabled: boolean;
+};
+const isPluginConfig = (config: Config | NextConfig): config is Config => {
+  return typeof config.enabled === 'boolean';
+};
+const withMinifyClassnames = (arg: Config | NextConfig) => {
+  if (isPluginConfig(arg)) {
+    return generateUpdateNextConfig(arg.enabled);
+  }
+  return generateUpdateNextConfig()(arg);
+};
 
 export default withMinifyClassnames;


### PR DESCRIPTION
BREAKING CHANGE: If you have an empty function call like `const withMinifyClassnames =
require('nextjs-plugin-minify-css-classname')()`, now you should remove the empty function call.