### PR TITLE
feat: allow setting prefix for class names

### DIFF
--- a/packages/nextjs-plugin-minify-css-classname/src/generator.spec.ts
+++ b/packages/nextjs-plugin-minify-css-classname/src/generator.spec.ts
@@ -54,4 +54,24 @@ describe('SequentialClassnameGenerator', () => {
     expect(generator.get('1')).toBe('a');
     expect(generator.get('1')).toBe('a');
   });
+
+  it('persists the prefix when prefix is specified.', () => {
+    const prefix = 'prefix-';
+    expect(generator.withPrefix(prefix)).toBe(generator);
+    expect(generator.getPrefix()).toBe(prefix);
+  });
+
+  it('returns the generated output with prefix when prefix is specified.', () => {
+    const prefix = 'prefix-';
+    generator.withPrefix(prefix);
+    expect(generator.get('1')).toBe(`${prefix}a`);
+    expect(generator.get('2')).toBe(`${prefix}b`);
+  });
+
+  it('keeps prefix as part of state.', () => {
+    expect(generator.withPrefix('prefix-1-').get('1')).toBe('prefix-1-a');
+    expect(generator.withPrefix('prefix-2-').get('2')).toBe('prefix-2-b');
+    expect(generator.withPrefix('prefix-2-').get('1')).toBe('prefix-1-a');
+    expect(generator.withPrefix('prefix-1-').get('2')).toBe('prefix-2-b');
+  });
 });

--- a/packages/nextjs-plugin-minify-css-classname/src/generator.ts
+++ b/packages/nextjs-plugin-minify-css-classname/src/generator.ts
@@ -2,17 +2,30 @@ const classNameCharset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
 
 export class SequentialClassnameGenerator {
   private map = new Map<string, string>();
+  private prefix = '';
 
   constructor(private charset = classNameCharset) {}
+
+  withPrefix(prefix: string) {
+    this.prefix = prefix;
+    return this;
+  }
+
+  getPrefix() {
+    return this.prefix;
+  }
 
   get(key: string): string {
     if (this.map.has(key)) {
       return this.map.get(key)!;
     }
     const encoded = this.encode(this.count);
-    this.map.set(key, encoded);
+    const withPrefix = this.prefix + encoded;
+    const result = withPrefix;
 
-    return encoded;
+    this.map.set(key, result);
+
+    return result;
   }
 
   private get count() {

--- a/packages/nextjs-plugin-minify-css-classname/src/index.ts
+++ b/packages/nextjs-plugin-minify-css-classname/src/index.ts
@@ -16,8 +16,13 @@ const getMinifiedLocalIdent = (
   return localIdentGenerator.get(`${relativePath}-${exportName}`);
 };
 
+export type Config = {
+  enabled: boolean;
+  prefix: string;
+};
+
 const generateUpdateNextConfig =
-  (enabled?: boolean) =>
+  (pluginConfig?: Partial<Config>) =>
   (
     originalNextConfig: NextConfig
   ): NextConfig & { webpack: NonNullable<NextConfig['webpack']> } => ({
@@ -27,6 +32,8 @@ const generateUpdateNextConfig =
         typeof originalNextConfig.webpack === 'function'
           ? originalNextConfig.webpack(config, context)
           : config;
+
+      const enabled = pluginConfig?.enabled;
 
       if (enabled === false || (enabled === undefined && context.dev)) {
         return webpackResult;
@@ -56,12 +63,9 @@ const generateUpdateNextConfig =
     },
   });
 
-export type Config = {
-  enabled: boolean;
-};
 export type DecoratedNextConfig = NextConfig & {
   webpack: NonNullable<NextConfig['webpack']>;
 };
 export const withMinifyClassnames = generateUpdateNextConfig();
-export const withMinifyClassnamesConfig = ({ enabled }: Config) =>
-  generateUpdateNextConfig(enabled);
+export const withMinifyClassnamesConfig = (config: Partial<Config>) =>
+  generateUpdateNextConfig(config);


### PR DESCRIPTION
Allows setting a prefix for generated class names.

Should help avoiding conflicts when also using external libraries (eg. Tailwind CSS) or if you want to distinguish your class names from some other generated names.